### PR TITLE
Fix main row width overflowing horizontally

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -36,6 +36,10 @@ a:hover {
 	font-size: 5vh;
 }
 
+.row {
+	margin: 0;
+}
+
 .row-status {
 	text-align: center;
 }


### PR DESCRIPTION
Bootstrap's magic makes rows in containers behave appropriately, but the negative margin here is overflowing the page and creating a horizontal scrollbar.  The easiest thing to do, instead of moving some elements around, is to just remove these margins which aren't serving any other functional purpose anyway.